### PR TITLE
Introduce ArgoDSM implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ discovery that uses machine learning to predict if a chemical compound is likely
 
 This repo contains several implementations of VMS generated from a Matrix Factorization model built by [SMURFF](https://github.com/ExaScience/smurff)
 
- * vms/pure_c: pure C with OmpSs, OpenMP, MPI, and GASPI 
+ * vms/pure_c: pure C with OmpSs, OpenMP, MPI, GASPI, and ArgoDSM
  * vms/af_py: Python ArrayFire implementation for CUDA, OpenCL and MKL
  * vms/af_cpp: C++ ArrayFire implementation for CUDA, OpenCL and MKL
  * vms/openacc: OpenACC implementation, with and witouth OmpSs

--- a/vms/pure_c/Makefile
+++ b/vms/pure_c/Makefile
@@ -19,12 +19,16 @@ ompss/predict:
 mpi/predict:
 	$(MAKE) -f Makefile.mpi
 
+argo/predict:
+	${MAKE} -f Makefile.argo
+
 all:
 	$(MAKE) -f Makefile.plain
 	$(MAKE) -f Makefile.omp
 	$(MAKE) -f Makefile.gpi
 	$(MAKE) -f Makefile.mpi
 	$(MAKE) -f Makefile.ompss
+	$(MAKE) -f Makefile.argo
 
 test:
 	$(MAKE) -f Makefile.ompss

--- a/vms/pure_c/Makefile.argo
+++ b/vms/pure_c/Makefile.argo
@@ -1,0 +1,14 @@
+
+ifndef ARGO_ROOT
+$(error Set ARGO_ROOT to the ArgoDSM install dir)
+endif
+
+CFLAGS    += -DUSE_ARGO -DVMS_PROFILING
+CFLAGS    += -I$(ARGO_ROOT)/include/argo
+LDFLAGS   += -L$(ARGO_ROOT)/lib
+LDFLAGS   += -Wl,-rpath=${ARGO_ROOT}/lib
+LDFLAGS   += -largo -largobackend-mpi -lnuma -lrt
+OBJFILES  += counters_impl.o
+OUTPUTDIR ?= argo
+
+include Makefile.omp

--- a/vms/pure_c/mpi.c
+++ b/vms/pure_c/mpi.c
@@ -277,6 +277,32 @@ void barrier() {
     gaspi_barrier(GASPI_GROUP_ALL, GASPI_BLOCK);
 }
 
+#elif defined(USE_ARGO)
+
+#include "argo.h"
+
+void mpi_init() {
+    argo_init(256*1024*1024UL,
+              256*1024*1024UL);
+
+    mpi_world_size = argo_number_of_nodes();
+    mpi_world_rank = argo_node_id();
+}
+
+void mpi_finit() {
+    argo_finalize();
+}
+
+void barrier() {
+    argo_barrier(1);
+}
+
+void send_predictions(int compound, const P_base data[num_proteins]) {}
+void send_features(int compound, const F_base data[num_features]) {}
+
+void send_inputs(int num_compounds,  F_flx features) { /*barrier();*/ }
+void combine_results(int num_compounds,  P_flx predictions) { barrier(); }
+
 #else
 
 void mpi_init() {

--- a/vms/pure_c/ompss.c
+++ b/vms/pure_c/ompss.c
@@ -3,6 +3,11 @@
 #include <stdio.h>
 #include <string.h>
 
+
+#ifdef USE_ARGO
+#include "argo.h"
+#endif
+
 #include "predict.h"
 
 static const char     *sizes[]   = { "EiB", "PiB", "TiB", "GiB", "MiB", "KiB", "B" };
@@ -57,6 +62,8 @@ void *dmalloc(unsigned long size, int segment_id)
     printf("dmalloc of %s\n", sizestr);
     free(sizestr);
     return nanos6_dmalloc(size, nanos6_equpart_distribution, 0, NULL);
+#elif defined(USE_ARGO)
+    return collective_alloc(size);
 #else
     return lmalloc(size, segment_id);
 #endif


### PR DESCRIPTION
This PR introduces an ArgoDSM implementation of VMS.

**NOTE**:

- `prepare_tb_input` is done collectively in the Argo version for the following reasons:
  - to be done faster.
  - to omit the node-wide synchronization in the `send_inputs` function for coherence.
  - to avoid _multiple-writer_ states in the Pyxis directory for the remotely-worked chunks.
  - to better place the distributed data under the _first-touch_ memory allocation policy.
- `check_result` is left to be done only by node0.
  - this can also be done collectively, but it is left as is to examine the coherence of data.
- the macro `mpi_world_rank_0_print` is introduced to filter all but node0 to print stuff:
  - feel free to change the implementation or name of this macro.