### PR TITLE
Revert collective data init for ArgoDSM

### DIFF
--- a/vms/pure_c/mpi.c
+++ b/vms/pure_c/mpi.c
@@ -300,7 +300,7 @@ void barrier() {
 void send_predictions(int compound, const P_base data[num_proteins]) {}
 void send_features(int compound, const F_base data[num_features]) {}
 
-void send_inputs(int num_compounds,  F_flx features) { /*barrier();*/ }
+void send_inputs(int num_compounds,  F_flx features) { barrier(); }
 void combine_results(int num_compounds,  P_flx predictions) { barrier(); }
 
 #else

--- a/vms/pure_c/test_bench.c
+++ b/vms/pure_c/test_bench.c
@@ -48,18 +48,7 @@ void prepare_tb_input(
 {
     perf_start(__FUNCTION__);
 
-#ifndef USE_ARGO
-    const int lo = 0;
-    const int hi = num_compounds;
-#else
-    const int num_compounds_per_rank = num_compounds / mpi_world_size;
-    const int block_start = num_compounds_per_rank * mpi_world_rank;
-
-    const int lo = block_start;
-    const int hi = block_start + num_compounds_per_rank;
-#endif
-
-    for (int c = lo; c < hi; c++)
+    for (int c = 0; c < num_compounds; c++)
         for (int p = 0; p < num_features; p++)
             out[c][p] = in [c%tb_num_compounds][p];
 
@@ -205,9 +194,7 @@ int main(int argc, char *argv[])
         double start = tick();
 
         mpi_world_rank_0_print("Prepare input\n");
-#ifndef USE_ARGO
         if (mpi_world_rank == 0)
-#endif
             prepare_tb_input(num_compounds, tb_input, tb_input_block);
         mpi_world_rank_0_print("Predicting\n");
 


### PR DESCRIPTION
As per our discussion, this PR reverts the collective data initialization for the ArgoDSM impleme-
ntation introduced in #1.

Conducting performance measurements going by that initialization setting, we found that it is
better for the data to be allocated on node_0, so the `prepare_tb_input` and `check_results`
functions execute faster. However, that also comes with the drawback that there will eventually
be a communication bottleneck on node_0 for a high number of cluster nodes.